### PR TITLE
bump inherits dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "minimatch": "~0.2.0",
     "fstream": "~0.1.17",
-    "inherits": "~1.0.0"
+    "inherits": "~2.0.0"
   },
   "devDependencies": {
     "tap": "",


### PR DESCRIPTION
I keep getting the following error message:

``` bash
npm WARN unmet dependency /usr/local/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore requires inherits@'~1.0.0' but will load
npm WARN unmet dependency /usr/local/lib/node_modules/npm/node_modules/fstream-npm/node_modules/inherits,
npm WARN unmet dependency which is version 2.0.0
```
